### PR TITLE
E2e tests

### DIFF
--- a/cmake/modules/CodeCoverage.cmake
+++ b/cmake/modules/CodeCoverage.cmake
@@ -113,7 +113,7 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
 		
 		# Capturing lcov counters and generating report
 		COMMAND ${LCOV_PATH} --directory . --capture --output-file ${_outputname}.info
-		COMMAND ${LCOV_PATH} --remove ${_outputname}.info 'build/*' 'tests/*' '/usr/*' --output-file ${_outputname}.info.cleaned
+		COMMAND ${LCOV_PATH} --remove ${_outputname}.info '*/build/*' '*/tests/*' '/usr/*' '*/vcpkg_installed/*' '*/_deps/*' --output-file ${_outputname}.info.cleaned
 		COMMAND ${GENHTML_PATH} -o ${_outputname} ${_outputname}.info.cleaned
 		COMMAND ${CMAKE_COMMAND} -E remove ${_outputname}.info ${_outputname}.info.cleaned
 		

--- a/src/gcsplugin.cpp
+++ b/src/gcsplugin.cpp
@@ -42,6 +42,10 @@ std::string globalBucketName;
 // Last error
 std::string lastError;
 
+HandleContainer active_handles;
+
+
+
 void InitHandle(Handle& h, ReaderPtr&& r_ptr)
 {
     h.var.reader = std::move(r_ptr);

--- a/src/gcsplugin.cpp
+++ b/src/gcsplugin.cpp
@@ -851,13 +851,13 @@ int driver_fclose(void* stream)
 
     if (!stream)
     {
-        return kFailure;
+        return kCloseEOF;
     }
 
     spdlog::debug("fclose {}", (void*)stream);
 
     auto stream_it = FindHandle(stream);
-    ERROR_NO_STREAM(stream_it, kFailure);
+    ERROR_NO_STREAM(stream_it, kCloseEOF);
     auto& h_ptr = *stream_it;
     const HandleType type = h_ptr->type;
 
@@ -875,7 +875,7 @@ int driver_fclose(void* stream)
 
     EraseRemove(stream_it);
 
-    return kSuccess;
+    return kCloseSuccess;
 }
 
 

--- a/src/gcsplugin.cpp
+++ b/src/gcsplugin.cpp
@@ -1145,7 +1145,7 @@ int driver_remove(const char* filename)
     INIT_NAMES_OR_ERROR(filename, bucket_name, object_name, kFailure);
 
     const auto status = client.DeleteObject(bucket_name, object_name);
-    if (!status.ok()) {
+    if (!status.ok() && status.code() != gc::StatusCode::kNotFound) {
         spdlog::error("Error deleting object: {} {}", (int)(status.code()), status.message());
         return kFailure;
     }

--- a/src/gcsplugin_internal.h
+++ b/src/gcsplugin_internal.h
@@ -53,6 +53,9 @@ namespace gcsplugin
     constexpr int kSuccess{ 1 };
     constexpr int kFailure{ 0 };
 
+    constexpr int kCloseSuccess{ 0 };
+    constexpr int kCloseEOF{ -1 };
+
     constexpr int kFalse{ 0 };
     constexpr int kTrue{ 1 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,7 +28,7 @@ target_include_directories(basic_test
   PRIVATE ${${PROJECT_NAME}_SOURCE_DIR}/src)
 
 set_property(TARGET basic_test PROPERTY
-  MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
   
 target_link_libraries(basic_test PRIVATE GTest::gtest GTest::gmock GTest::gmock_main google-cloud-cpp::storage khiopsdriver_file_gcs)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,9 +27,6 @@ target_compile_options(basic_test
 target_include_directories(basic_test
   PRIVATE ${${PROJECT_NAME}_SOURCE_DIR}/src)
 
-set_property(TARGET basic_test PROPERTY
-  MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
-  
 target_link_libraries(basic_test PRIVATE GTest::gtest GTest::gmock GTest::gmock_main google-cloud-cpp::storage khiopsdriver_file_gcs)
 
 gtest_discover_tests(basic_test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,8 +25,7 @@ target_compile_options(basic_test
 )
 
 target_include_directories(basic_test
-  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
-         ${${PROJECT_NAME}_SOURCE_DIR}/src)
+  PRIVATE ${${PROJECT_NAME}_SOURCE_DIR}/src)
 
 target_link_libraries(basic_test PRIVATE GTest::gtest GTest::gmock GTest::gmock_main google-cloud-cpp::storage khiopsdriver_file_gcs)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,9 @@ target_compile_options(basic_test
 target_include_directories(basic_test
   PRIVATE ${${PROJECT_NAME}_SOURCE_DIR}/src)
 
+set_property(TARGET basic_test PROPERTY
+  MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  
 target_link_libraries(basic_test PRIVATE GTest::gtest GTest::gmock GTest::gmock_main google-cloud-cpp::storage khiopsdriver_file_gcs)
 
 gtest_discover_tests(basic_test)

--- a/test/basic_test.cpp
+++ b/test/basic_test.cpp
@@ -1382,7 +1382,7 @@ TEST_F(GCSDriverTestFixture, OpenWriteMode_OK)
         .WillOnce(Return(CreateResumableUploadResponse{ upload_id }));
     
     
-    WriteFile expected;
+    gcsplugin::WriteFile expected;
     expected.bucketname_ = mock_bucket;
     expected.filename_ = mock_object;
 

--- a/test/basic_test.cpp
+++ b/test/basic_test.cpp
@@ -93,6 +93,20 @@ TEST(GCSDriverTest, GetFileSizeNonexistentFailure)
 	ASSERT_EQ(driver_disconnect(), kSuccess);
 }
 
+TEST(GCSDriverTest, FileExists)
+{
+	ASSERT_EQ(driver_connect(), kSuccess);
+	ASSERT_EQ(driver_exist("gs://data-test-khiops-driver-gcs/khiops_data/samples/Adult/Adult.txt"), kSuccess);
+	ASSERT_EQ(driver_disconnect(), kSuccess);
+}
+
+TEST(GCSDriverTest, DirExists)
+{
+	ASSERT_EQ(driver_connect(), kSuccess);
+	ASSERT_EQ(driver_exist("gs://data-test-khiops-driver-gcs/khiops_data/samples/Adult/"), kSuccess);
+	ASSERT_EQ(driver_disconnect(), kSuccess);
+}
+
 TEST(GCSDriverTest, DriverConnectMissingCredentialsFailure)
 {
     auto env = boost::this_process::environment();

--- a/test/basic_test.cpp
+++ b/test/basic_test.cpp
@@ -556,37 +556,37 @@ TEST_F(GCSDriverTestFixture, Close)
 
     // null pointer
     CheckHandlesSize(3);
-    ASSERT_EQ(driver_fclose(nullptr), kFailure);
+    ASSERT_EQ(driver_fclose(nullptr), kCloseEOF);
     CheckHandlesSize(3);
     check_handle(read_h);
 
     // address unknown
-    ASSERT_EQ(driver_fclose(&unknown), kFailure);
+    ASSERT_EQ(driver_fclose(&unknown), kCloseEOF);
     CheckHandlesSize(3);
     check_handle(read_h);
 
     // close read_h
     // additional post-condition: write_h, that was the last handle, must have been swapped to the front
-    ASSERT_EQ(driver_fclose(read_h), kSuccess);
+    ASSERT_EQ(driver_fclose(read_h), kCloseSuccess);
     CheckHandlesSize(2);
     check_handle(write_h);
 
     // try to close read_h handle again
-    ASSERT_EQ(driver_fclose(read_h), kFailure);
+    ASSERT_EQ(driver_fclose(read_h), kCloseEOF);
     CheckHandlesSize(2);
     check_handle(write_h);
 
     // close write_h
-    ASSERT_EQ(driver_fclose(write_h), kSuccess);
+    ASSERT_EQ(driver_fclose(write_h), kCloseSuccess);
     CheckHandlesSize(1);
     check_handle(another_read_h);
 
     // close last handle
-    ASSERT_EQ(driver_fclose(another_read_h), kSuccess);
+    ASSERT_EQ(driver_fclose(another_read_h), kCloseSuccess);
     CheckHandlesEmpty();
 
     // try closing a handle again while container is empty
-    ASSERT_EQ(driver_fclose(read_h), kFailure);
+    ASSERT_EQ(driver_fclose(read_h), kCloseEOF);
     CheckHandlesEmpty();
 }
 

--- a/test/basic_test.cpp
+++ b/test/basic_test.cpp
@@ -108,18 +108,18 @@ TEST(GCSDriverTest, DirExists)
 
 TEST(GCSDriverTest, DriverConnectMissingCredentialsFailure)
 {
-    constexpr char* badtoken = "GCP_TOKEN=/tmp/notoken.json";
-    constexpr char* notoken = "GCP_TOKEN=";
+    constexpr const char* badtoken = "GCP_TOKEN=/tmp/notoken.json";
+    constexpr const char* notoken = "GCP_TOKEN=";
 #ifdef _WIN32
-    _putenv(badtoken);
+    _putenv((char*)badtoken);
 #else
-    putenv(badtoken);
+    putenv((char*)badtoken);
 #endif
 	ASSERT_EQ(driver_connect(), kFailure);
 #ifdef _WIN32
-    _putenv(notoken);
+    _putenv((char*)notoken);
 #else
-    putenv(notoken);
+    putenv((char*)notoken);
 #endif
 }
 
@@ -142,12 +142,13 @@ void setup_bad_credentials() {
 #endif
 }
 
-void cleanup_bad_credentials() {
-    constexpr char* notoken = "GCP_TOKEN=";
+void cleanup_bad_credentials()
+{
+    constexpr const char* notoken = "GCP_TOKEN=";
 #ifdef _WIN32
-    _putenv(notoken);
+    _putenv((char*)notoken);
 #else
-    putenv(notoken);
+    putenv((char*)notoken);
 #endif
 }
 

--- a/test/basic_test.cpp
+++ b/test/basic_test.cpp
@@ -136,7 +136,7 @@ void setup_bad_credentials() {
     std::stringstream envVar;
     envVar << "GCP_TOKEN=" << tempCredsFile.str();
 #ifdef _WIN32
-    _putenv(envVar.str());
+    _putenv((char*)(envVar.str().c_str()));
 #else
     putenv((char*)(envVar.str().c_str()));
 #endif

--- a/test/basic_test.cpp
+++ b/test/basic_test.cpp
@@ -125,6 +125,7 @@ TEST(GCSDriverTest, GetFileSizeInvalidCredentialsFailure)
     setup_bad_credentials();
 	ASSERT_EQ(driver_connect(), kSuccess);
 	ASSERT_EQ(driver_getFileSize("gs://data-test-khiops-driver-gcs/khiops_data/samples/Adult/Adult.txt"), -1);
+    ASSERT_STRNE(driver_getlasterror(), NULL);
 	ASSERT_EQ(driver_disconnect(), kSuccess);
     cleanup_bad_credentials();
 }

--- a/test/drivertest.cpp
+++ b/test/drivertest.cpp
@@ -56,9 +56,45 @@ TEST(GCSDriverTest, End2EndTest_SingleFile_512B_OK)
     ASSERT_EQ(test_status, kSuccess);
 }
 
-TEST(GCSDriverTest, End2EndTest_MultipartFile_512KB_OK)
+TEST(GCSDriverTest, End2EndTest_MultipartBQFile_512KB_OK)
 {
 	const char* inputFilename = "gs://data-test-khiops-driver-gcs/khiops_data/bq_export/Adult/Adult-split-00000000000*.txt";
+
+	/* default size of buffer passed to driver */
+	int nBufferSize = 512 * 1024;
+
+	/* error indicator in case of error */
+	int test_status = launch_test(inputFilename, nBufferSize);
+    ASSERT_EQ(test_status, kSuccess);
+}
+
+TEST(GCSDriverTest, End2EndTest_MultipartBQEmptyFile_512KB_OK)
+{
+	const char* inputFilename = "gs://data-test-khiops-driver-gcs/khiops_data/bq_export/Adult_empty/Adult-split-00000000000*.txt";
+
+	/* default size of buffer passed to driver */
+	int nBufferSize = 512 * 1024;
+
+	/* error indicator in case of error */
+	int test_status = launch_test(inputFilename, nBufferSize);
+    ASSERT_EQ(test_status, kSuccess);
+}
+
+TEST(GCSDriverTest, End2EndTest_MultipartSplitFile_512KB_OK)
+{
+	const char* inputFilename = "gs://data-test-khiops-driver-gcs/khiops_data/split/Adult/Adult-split-0*.txt";
+
+	/* default size of buffer passed to driver */
+	int nBufferSize = 512 * 1024;
+
+	/* error indicator in case of error */
+	int test_status = launch_test(inputFilename, nBufferSize);
+    ASSERT_EQ(test_status, kSuccess);
+}
+
+TEST(GCSDriverTest, End2EndTest_MultipartSubsplitFile_512KB_OK)
+{
+	const char* inputFilename = "gs://data-test-khiops-driver-gcs/khiops_data/split/Adult_subsplit/**/Adult-split-0*.txt";
 
 	/* default size of buffer passed to driver */
 	int nBufferSize = 512 * 1024;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,6 +4,7 @@
     "description": "Setting up C++ for Google Cloud with CMake and vcpkg",
     "dependencies": [
         {"name": "boost-uuid"},
+        {"name": "boost-process"},
         {"name": "fmt"},
         {"name": "google-cloud-cpp", "default-features": false, "features": ["storage"]},
         {"name": "spdlog"}


### PR DESCRIPTION
Simplify coverage report by excluding unwanted files

Add support for token passed via GCP_TOKEN variable

Better error handling for missing files and bad auth in GetFileSize

Fixed fclose return value